### PR TITLE
feat/ Return request url only

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,26 @@ num_found, df = solr_request(
 > To see expected fields check the documentation at: https://www.ebi.ac.uk/mi/impc/solrdoc/
 ```
 
+## c. URL only
+
+Users might want help producing the URL to fetch the data without the need of a DataFrame. Use the flag `url_only=True` to print or return the URL for your query.
+
+```python
+url, _ = solr_request(
+    core='genotype-phenotype',
+    params={
+        'q': '*:*',
+        'rows': 10,
+        'fl': 'marker_symbol,allele_symbol'
+    },
+    url_only=True
+)
+> "https://www.ebi.ac.uk/mi/impc/solr/genotype-phenotype/select?q=%2A%3A%2A&rows=10&fl=marker_symbol%2Callele_symbol"
+
+print(url)
+> "https://www.ebi.ac.uk/mi/impc/solr/genotype-phenotype/select?q=%2A%3A%2A&rows=10&fl=marker_symbol%2Callele_symbol"
+```
+
 # 2. Batch Solr Request
 
 `batch_solr_request` is available for large queries. This solves issues where a request is too large to fit into memory or where it puts a lot of strain on the API.

--- a/impc_api/solr_request.py
+++ b/impc_api/solr_request.py
@@ -10,7 +10,7 @@ pd.set_option("display.max_rows", 15)
 pd.set_option("display.max_columns", None)
 
 # Create helper function
-def solr_request(core, params, silent=False, validate=False):
+def solr_request(core, params, silent=False, validate=False, url_only=False):
     """Performs a single Solr request to the IMPC Solr API.
 
     Args:
@@ -22,11 +22,22 @@ def solr_request(core, params, silent=False, validate=False):
         validate (bool, optional): default False
             If True, validates the parameters against the core schema and raises warnings
             if any parameter seems invalid.
+        url_only (bool, optional): default False
+            If true, returns the request URL but no data. 
 
 
     Returns:
-        num_found: Number of docs found.
-        pandas.DataFrame: Pandas.DataFrame object with the information requested.
+        Union[Tuple[int, pandas.DataFrame], Tuple[str, None]]:
+            - If url_only is False:
+                A tuple containing:
+                    num_found (int): Number of documents found.
+                    df (pandas.DataFrame): DataFrame object with the information requested.
+            
+            - If url_only is True:
+                A tuple containing:
+                    url (str): The URL of the request if status_code is 200, otherwise None.
+                    None: Placeholder for consistency.
+
 
     Example query:
         num_found, df = solr_request(
@@ -70,6 +81,16 @@ def solr_request(core, params, silent=False, validate=False):
     solr_url = base_url + core + "/select"
 
     response = requests.get(solr_url, params=params)
+
+    if url_only:
+        if response.status_code == 200:
+            print(response.request.url)
+            return response.request.url, None
+        else:
+            print(f"Error: {response.status_code}\n{response.text}")
+        return None, None
+
+
     if not silent:
         print(f"\nYour request:\n{response.request.url}\n")
 


### PR DESCRIPTION
Adds a flag `url_only` to return/print the URL. 
This should be useful to craft URLs without the need of getting DataFrames, print them to the console, or returning them into a variable to use them somewhere else in the code. 